### PR TITLE
Adding a unit variable to TerminalWidget.js

### DIFF
--- a/TerminalWidget.js
+++ b/TerminalWidget.js
@@ -161,7 +161,6 @@ function createWidget(data) {
   periodLine.textColor = new Color(COLORS.period);
   periodLine.font = new Font(FONT_NAME, FONT_SIZE);
 
-
   // Line 7 - Various Device Stats
   const deviceStatsLine = stack.addText(`📊 | ⚡︎ ${data.device.battery}%, ☀ ${data.device.brightness}%`);
   deviceStatsLine.textColor = new Color(COLORS.deviceStats);


### PR DESCRIPTION
This commit adds a metric variable to the TerminalWidget.js file.

Original note:

A variable named TEMP_UNIT has been added to contain the name of the desired unit System that the user wants to use.
This unit applies to the temperature when setting the OpenWeather URL in line 229.
